### PR TITLE
Fix context bind for fetchBuiltin

### DIFF
--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -42,7 +42,7 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
         if (args.fetch) {
             this.fetchBuiltin = args.fetch;
         } else {
-            this.fetchBuiltin = (global as any).fetch;
+            this.fetchBuiltin = (global as any).fetch.bind(window);
         }
     }
 

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -42,7 +42,7 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
         if (args.fetch) {
             this.fetchBuiltin = args.fetch;
         } else {
-            this.fetchBuiltin = (global as any).fetch.bind(window);
+            this.fetchBuiltin = (global as any).fetch.bind(global);
         }
     }
 


### PR DESCRIPTION
This tweak resolves the error while using greymass/anchor-link with the message of:

> Failed to execute 'fetch' on 'Window': Illegal invocation

The unit tests still return the same results as before the change, though I am not certain this change wouldn't cause problems elsewhere with how it's being used.